### PR TITLE
Simplify user registration to single consent step

### DIFF
--- a/src/registration.py
+++ b/src/registration.py
@@ -22,11 +22,15 @@ class UserRegistration:
             telegram_id: int,
             first_name: str,
             last_name: str,
-            full_name: str,
-            birth_date: datetime,
+            full_name: str | None = None,
+            birth_date: datetime | None = None,
             referrer_id: int | None = None,
             personal_data_consent: bool = False
     ) -> CustomUser:
+        if not full_name:
+            parts = [part for part in [first_name, last_name] if part]
+            full_name = " ".join(parts) if parts else None
+
         qr_code = generate_qr_code(telegram_id)
 
         user = CustomUser(

--- a/src/run.py
+++ b/src/run.py
@@ -1,5 +1,4 @@
 import os
-import re
 import logging
 import asyncio
 from datetime import datetime
@@ -9,7 +8,7 @@ from aiogram.filters import CommandStart
 from aiogram.types import Message, CallbackQuery, FSInputFile
 from aiogram.enums import ParseMode
 from aiogram.client.default import DefaultBotProperties
-from aiogram.fsm.state import State, StatesGroup
+from aiogram.fsm.state import StatesGroup
 from aiogram.fsm.context import FSMContext
 from sqlalchemy import select
 
@@ -29,8 +28,7 @@ dp = Dispatcher()
 
 
 class Registration(StatesGroup):
-    waiting_for_fio = State()
-    waiting_for_birth_date = State()
+    pass
 
 
 async def save_bot_activity(session, telegram_id: int, action: str):
@@ -86,17 +84,7 @@ async def command_start_handler(message: Message, state: FSMContext):
                 text=(
                     "👋 Здравствуйте!\n"
                     "Добро пожаловать в нашу систему лояльности.\n"
-                    "Прежде чем начать регистрацию, пожалуйста, ознакомьтесь с "
-                    "условиями обработки персональных данных.\n"
-                    "🔐 Мы собираем и обрабатываем следующие данные:\n"
-                    " • ФИО\n"
-                    " • Дата рождения\n"
-                    " • Telegram ID\n"
-                    "\n"
-                    "Цель обработки данных:\n"
-                    " • Регистрация в бонусной программе\n"
-                    " • Персонализированные предложения\n"
-                    " • Ведение внутренней аналитики\n\n"
+                    "Прежде чем начать, пожалуйста, ознакомьтесь с условиями обработки персональных данных.\n\n"
                     "📄 Полный текст политики доступен здесь:\n"
                     "👉 https://docs.google.com/document/d/13BI-g30MvueQS2fSvaVdnKA9M2LkyEBUTaJ0GFI5f2g/edit?usp=sharing\n\n"
                     "Нажимая кнопку «Я согласен», вы подтверждаете своё согласие на обработку персональных данных "
@@ -117,9 +105,22 @@ async def consent_callback(callback: CallbackQuery, state: FSMContext):
             return await callback.answer()
 
         await state.update_data(personal_data_consent=True)
-        await callback.message.answer("Спасибо за согласие. Пожалуйста, введите ваше ФИО:")
-        await state.set_state(Registration.waiting_for_fio)
+        data = await state.get_data()
+        user = await user_service.create_user(
+            telegram_id=callback.from_user.id,
+            first_name=callback.from_user.first_name,
+            last_name=callback.from_user.last_name,
+            referrer_id=data.get("referrer_id"),
+            personal_data_consent=True,
+        )
 
+    await callback.message.answer("Спасибо! Вы успешно зарегистрированы.")
+    if user.qr_code and os.path.exists(user.qr_code):
+        await callback.message.answer(
+            "Вот ваша кнопка для получения QR-кода:",
+            reply_markup=get_qr_code_button(),
+        )
+    await state.clear()
     await callback.answer()
 
 
@@ -155,48 +156,6 @@ async def callback_handler(callback: CallbackQuery):
     await callback.answer()
 
 
-@dp.message(Registration.waiting_for_fio)
-async def process_fio(message: Message, state: FSMContext):
-    FIO_REGEX = r"^[А-ЯЁ][а-яё]+ [А-ЯЁ][а-яё]+ [А-ЯЁ][а-яё]+$"
-    if not re.match(FIO_REGEX, message.text.strip()):
-        await message.answer(
-            "❌ Некорректный формат ФИО.\n"
-            "Например: <b>Иванов Иван Иванович</b>",
-            parse_mode="HTML"
-        )
-        return
-
-    await state.update_data(full_name=message.text.strip())
-    await message.answer("Введите вашу дату рождения (в формате ДД.ММ.ГГГГ):")
-    await state.set_state(Registration.waiting_for_birth_date)
-
-@dp.message(Registration.waiting_for_birth_date)
-async def process_birth_date(message: Message, state: FSMContext):
-    try:
-        birth_date = datetime.strptime(message.text, "%d.%m.%Y")
-    except ValueError:
-        await message.answer("Неверный формат. Введите дату как ДД.ММ.ГГГГ.")
-        return
-
-    data = await state.get_data()
-
-    async with SessionLocal() as session:
-        user_service = UserRegistration(session)
-        user = await user_service.create_user(
-            telegram_id=data["telegram_id"],
-            first_name=data["first_name"],
-            last_name=data["last_name"],
-            full_name=data["full_name"],
-            birth_date=birth_date,
-            referrer_id=data.get("referrer_id"),
-            personal_data_consent=data.get("personal_data_consent", False)
-        )
-
-    await message.answer("Спасибо! Вы успешно зарегистрированы.")
-    if user.qr_code and os.path.exists(user.qr_code):
-        await message.answer("Вот ваша кнопка для получения QR-кода:", reply_markup=get_qr_code_button())
-
-    await state.clear()
 
 
 async def main():


### PR DESCRIPTION
## Summary
- streamline start message to request only personal data consent
- register user immediately after consent without collecting name or birth date
- allow optional full name and birth date in registration service

## Testing
- `pytest`
- `python -m py_compile src/run.py src/registration.py`


------
https://chatgpt.com/codex/tasks/task_e_689424ad32f88326a20a10790180be94