### PR TITLE
Read broadcast bot token from environment

### DIFF
--- a/src/broadcast.py
+++ b/src/broadcast.py
@@ -11,9 +11,14 @@ from src.database.models import SessionLocal, CustomUser, engine
 
 load_dotenv()
 
-BOT_TOKEN = os.getenv("BOT_TOKEN")
-bot = Bot(token='7730296602:AAEKA5njTkND1U5NqVFprwCmLlJcbmuDbW4', default=DefaultBotProperties(parse_mode=ParseMode.HTML))
 logger = logging.getLogger(__name__)
+BOT_TOKEN = os.getenv("BOT_TOKEN")
+
+if not BOT_TOKEN:
+    logger.error("BOT_TOKEN не задан в переменных окружения. Рассылка остановлена.")
+    raise RuntimeError("BOT_TOKEN is required for broadcast")
+
+bot = Bot(token=BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
 
 
 async def send_broadcast_message(message_obj):


### PR DESCRIPTION
## Summary
- load the broadcast bot token from the environment and fail fast with logging when it is missing
- create the aiogram Bot with the configured token instead of a hardcoded literal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2f29f03483269de9478a00b153fe