### PR TITLE
Fix receipt duplicate allocations and add regression test

### DIFF
--- a/backend/api/tests/test_onec_receipt.py
+++ b/backend/api/tests/test_onec_receipt.py
@@ -1,0 +1,91 @@
+import json
+import time
+import hmac
+import hashlib
+
+from django.test import TestCase, Client
+
+from api import security
+from main.models import Transaction, CustomUser
+
+
+class OneCReceiptTests(TestCase):
+    def setUp(self):
+        security.API_KEY = 'test-key'
+        security.HMAC_SECRET = 'test-secret'
+        security.DISABLE_HMAC = False
+        self.client = Client()
+
+    def _headers(self, body: bytes):
+        ts = str(int(time.time()))
+        sign = hmac.new(
+            security.HMAC_SECRET.encode(),
+            f"{ts}.".encode() + body,
+            hashlib.sha256,
+        ).hexdigest()
+        return {
+            'HTTP_X_API_KEY': security.API_KEY,
+            'HTTP_X_TIMESTAMP': ts,
+            'HTTP_X_SIGN': sign,
+        }
+
+    def test_repeat_receipt_does_not_duplicate_transactions(self):
+        payload = {
+            'receipt_guid': 'R-123',
+            'datetime': '2025-03-10T12:30:00+00:00',
+            'store_id': '77',
+            'customer': {
+                'telegram_id': 9001,
+            },
+            'positions': [
+                {
+                    'product_code': 'SKU-1',
+                    'name': 'Test product',
+                    'quantity': '2',
+                    'price': '100.00',
+                    'discount_amount': '10.00',
+                    'is_promotional': False,
+                    'line_number': 1,
+                },
+            ],
+            'totals': {
+                'total_amount': '180.00',
+                'discount_total': '20.00',
+                'bonus_spent': '0',
+                'bonus_earned': '18.00',
+            },
+        }
+
+        body = json.dumps(payload).encode()
+
+        first_headers = {
+            **self._headers(body),
+            'HTTP_X_IDEMPOTENCY_KEY': '00000000-0000-0000-0000-000000000001',
+        }
+        resp = self.client.post(
+            '/onec/receipt', data=body, content_type='application/json', follow=True, **first_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data['status'], 'ok')
+        self.assertEqual(data['created_count'], 1)
+        self.assertEqual(len(data['allocations']), 1)
+        self.assertEqual(Transaction.objects.count(), 1)
+
+        # repeat with a different idempotency key to simulate retry from 1C
+        second_headers = {
+            **self._headers(body),
+            'HTTP_X_IDEMPOTENCY_KEY': '00000000-0000-0000-0000-000000000002',
+        }
+        resp_repeat = self.client.post(
+            '/onec/receipt', data=body, content_type='application/json', follow=True, **second_headers
+        )
+        self.assertEqual(resp_repeat.status_code, 200)
+        repeat_data = resp_repeat.json()
+        self.assertEqual(repeat_data['status'], 'already exists')
+        self.assertEqual(repeat_data['created_count'], 0)
+        self.assertEqual(repeat_data['allocations'], [])
+        self.assertEqual(Transaction.objects.count(), 1)
+
+        user = CustomUser.objects.get(telegram_id=payload['customer']['telegram_id'])
+        self.assertEqual(user.purchase_count, 1)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -311,14 +311,6 @@ def onec_receipt(request):
                             "bonus_earned": float(pos_bonus_earned),
                         })
                         first = False
-                    
-                    created_count += 1
-                    allocations.append({
-                        "product_code": code,
-                        "quantity": float(qty),
-                        "total_amount": float(pos_total),
-                        "bonus_earned": float(pos_bonus_earned),
-                    })
                 except IntegrityError:
                     continue
 

--- a/backend/backend/test_settings.py
+++ b/backend/backend/test_settings.py
@@ -10,3 +10,5 @@ DATABASES = {
 }
 
 USE_TZ = False
+APPEND_SLASH = False
+SECURE_SSL_REDIRECT = False


### PR DESCRIPTION
## Summary
- ensure receipt allocations and created counter only update when a transaction is newly created
- add a regression test covering repeated receipt submission without creating duplicates
- adjust test settings to disable redirects that interfere with API client tests

## Testing
- python backend/manage.py test api.tests.test_onec_receipt --settings=backend.test_settings

------
https://chatgpt.com/codex/tasks/task_e_68cdf7157ad883268d53be4b620ee1ea