### PR TITLE
Fix onec_product_sync response handling

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -485,9 +485,10 @@ def onec_product_sync(request):
         if not ser.is_valid():
             return JsonResponse({"detail": ser.errors}, status=400)
         data = ser.validated_data
+        one_c_guid = data.get("one_c_guid")
 
         defaults = {
-            "one_c_guid": data.get("one_c_guid"),
+            "one_c_guid": one_c_guid,
             "name": data["name"],
             "price": data["price"],
             "category": data["category"],
@@ -499,21 +500,6 @@ def onec_product_sync(request):
             product_code=data["product_code"], defaults=defaults
         )
 
-        try:
-            guid_for_resp = one_c_guid
-            if not guid_for_resp:
-                m = OneCClientMap.objects.filter(user=user).first()
-                guid_for_resp = getattr(m, one_c_guid, None)
-        except Exception:
-            guid_for_resp = one_c_guid
-        
-        try:
-            guid_for_resp = one_c_guid
-            if not guid_for_resp:
-                m = OneCClientMap.objects.filter(user=user).first()
-                guid_for_resp = getattr(m, "one_c_guid", None)
-        except Exception:
-            guid_for_resp = one_c_guid
         resp = {
             "status": "created" if created else "updated",
             "product": {


### PR DESCRIPTION
## Summary
- store one_c_guid from validated product sync payload to reuse across updates and responses
- simplify product sync response logic to rely on persisted product GUID and remove references to undefined variables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd3509c52883268984f4c646ddbdfa