### PR TITLE
Handle Windows QR code paths

### DIFF
--- a/src/qr_code.py
+++ b/src/qr_code.py
@@ -1,8 +1,11 @@
-import qrcode
-import os
+from pathlib import Path, PureWindowsPath
 
-QR_CODES_DIR = "qr_codes"
-os.makedirs(QR_CODES_DIR, exist_ok=True)
+import qrcode
+
+
+BASE_DIR = Path(__file__).resolve().parent
+QR_CODES_DIR = BASE_DIR / "qr_codes"
+QR_CODES_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def generate_qr_code(telegram_id: int) -> str:
@@ -17,7 +20,33 @@ def generate_qr_code(telegram_id: int) -> str:
 
     img = qr.make_image(fill_color="black", back_color="white")
     filename = f"qr_{telegram_id}.png"
-    filepath = os.path.join(QR_CODES_DIR, filename)
+    filepath = QR_CODES_DIR / filename
     img.save(filepath)
 
-    return filepath
+    return str(filepath)
+
+
+def resolve_qr_code_path(path: str) -> Path:
+    """Возвращает абсолютный путь к QR-коду."""
+    raw_path = path.strip()
+    file_path = Path(raw_path)
+
+    if file_path.is_absolute() and file_path.exists():
+        return file_path
+
+    # Попробуем восстановить относительный путь от каталога исходников
+    resolved = (BASE_DIR / file_path).resolve()
+    if resolved.exists():
+        return resolved
+
+    windows_path = PureWindowsPath(raw_path)
+    windows_parts = list(windows_path.parts)
+
+    if "qr_codes" in windows_parts:
+        relative_parts = windows_parts[windows_parts.index("qr_codes") + 1 :]
+        candidate = QR_CODES_DIR.joinpath(*relative_parts)
+        if candidate.exists():
+            return candidate
+
+    filename = windows_path.name or file_path.name
+    return (QR_CODES_DIR / filename).resolve()

--- a/src/tests/test_qr_code_paths.py
+++ b/src/tests/test_qr_code_paths.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import qr_code
+
+
+@pytest.fixture(autouse=True)
+def reset_qr_paths(tmp_path, monkeypatch):
+    base_dir = tmp_path / "src"
+    codes_dir = base_dir / "qr_codes"
+    codes_dir.mkdir(parents=True)
+    monkeypatch.setattr(qr_code, "BASE_DIR", base_dir)
+    monkeypatch.setattr(qr_code, "QR_CODES_DIR", codes_dir)
+    yield
+
+
+def test_resolve_relative_path(tmp_path):
+    expected = qr_code.QR_CODES_DIR / "qr_1.png"
+    expected.touch()
+
+    resolved = qr_code.resolve_qr_code_path("qr_codes/qr_1.png")
+
+    assert resolved == expected
+
+
+def test_resolve_windows_absolute_path(tmp_path):
+    expected = qr_code.QR_CODES_DIR / "qr_2.png"
+    expected.touch()
+
+    raw_path = r"C:\\bots\\project\\src\\qr_codes\\qr_2.png"
+
+    resolved = qr_code.resolve_qr_code_path(raw_path)
+
+    assert resolved == expected
+
+
+def test_resolve_windows_relative_path(tmp_path):
+    expected = qr_code.QR_CODES_DIR / "qr_3.png"
+    expected.touch()
+
+    raw_path = r"qr_codes\\qr_3.png"
+
+    resolved = qr_code.resolve_qr_code_path(raw_path)
+
+    assert resolved == expected
+
+
+def test_returns_target_location_when_file_missing(tmp_path):
+    resolved = qr_code.resolve_qr_code_path("qr_codes/qr_unknown.png")
+
+    assert resolved == qr_code.QR_CODES_DIR / "qr_unknown.png"


### PR DESCRIPTION
## Summary
- normalize stored QR-code paths so Windows-style values resolve to the local storage
- keep falling back to the known QR storage directory when the referenced file has moved
- add regression tests that cover the supported path permutations

## Testing
- pytest src/tests/test_qr_code_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68e1005015cc8326b7dc36897b715d98